### PR TITLE
Change movement keys for Spanish Dvorak

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -190,14 +190,20 @@ vim.keymap.set('t', '<Esc><Esc>', '<C-\\><C-n>', { desc = 'Exit terminal mode' }
 -- vim.keymap.set('n', '<up>', '<cmd>echo "Use k to move!!"<CR>')
 -- vim.keymap.set('n', '<down>', '<cmd>echo "Use j to move!!"<CR>')
 
+-- Movement keys for a Spanish dvorak layout
+vim.keymap.set({'n', 'x', 'o'}, 'r', 'h', { desc = 'Move left' })
+vim.keymap.set({'n', 'x', 'o'}, 's', 'l', { desc = 'Move right' })
+vim.keymap.set({'n', 'x', 'o'}, 'c', 'k', { desc = 'Move up' })
+vim.keymap.set({'n', 'x', 'o'}, 't', 'j', { desc = 'Move down' })
+
 -- Keybinds to make split navigation easier.
---  Use CTRL+<hjkl> to switch between windows
+--  Use CTRL+r/s/c/t to switch between windows
 --
 --  See `:help wincmd` for a list of all window commands
-vim.keymap.set('n', '<C-h>', '<C-w><C-h>', { desc = 'Move focus to the left window' })
-vim.keymap.set('n', '<C-l>', '<C-w><C-l>', { desc = 'Move focus to the right window' })
-vim.keymap.set('n', '<C-j>', '<C-w><C-j>', { desc = 'Move focus to the lower window' })
-vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper window' })
+vim.keymap.set('n', '<C-r>', '<C-w><C-h>', { desc = 'Move focus to the left window' })
+vim.keymap.set('n', '<C-s>', '<C-w><C-l>', { desc = 'Move focus to the right window' })
+vim.keymap.set('n', '<C-t>', '<C-w><C-j>', { desc = 'Move focus to the lower window' })
+vim.keymap.set('n', '<C-c>', '<C-w><C-k>', { desc = 'Move focus to the upper window' })
 
 -- NOTE: Some terminals have colliding keymaps or are not able to send distinct keycodes
 -- vim.keymap.set("n", "<C-S-h>", "<C-w>H", { desc = "Move window to the left" })


### PR DESCRIPTION
## Summary
- remap movement keys to `r/s/c/t`
- adjust split navigation to use the new mappings

## Testing
- `stylua --check nvim`

------
https://chatgpt.com/codex/tasks/task_e_685aa0533f5c8322bb73012ebf865758