### PR TITLE
Fix freeze when using :! shell commands

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -865,6 +865,12 @@ require('lazy').setup({
         default = { 'lsp', 'path', 'snippets', 'lazydev' },
         providers = {
           lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
+          cmdline = {
+            enabled = function()
+              return vim.fn.getcmdtype() ~= ':'
+                or not vim.fn.getcmdline():match("^[%0-9,'<>%-]*!")
+            end,
+          },
         },
       },
 


### PR DESCRIPTION
## Summary
- disable blink.cmp's cmdline completion when executing shell commands

## Testing
- `nvim --headless +'qa'` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c06008dc48322a391642469c4ecd5