### PR TITLE
Add TypeScript auto imports

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -688,8 +688,8 @@ require('lazy').setup({
         -- Some languages (like typescript) have entire language plugins that can be useful:
         --    https://github.com/pmizio/typescript-tools.nvim
         --
-        -- But for many setups, the LSP (`ts_ls`) will work just fine
-        -- ts_ls = {},
+        -- But for many setups, the LSP (`tsserver`) will work just fine
+        tsserver = {},
         --
 
         lua_ls = {
@@ -997,7 +997,7 @@ require('lazy').setup({
   --    This is the easiest way to modularize your config.
   --
   --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
-  -- { import = 'custom.plugins' },
+  { import = 'custom.plugins' },
   --
   -- For additional information with loading, sourcing and examples see `:help lazy.nvim-🔌-plugin-spec`
   -- Or use telescope!

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -2,4 +2,24 @@
 --  I promise not to create any merge conflicts in this directory :)
 --
 -- See the kickstart.nvim README for more information
-return {}
+return {
+  {
+    'jose-elias-alvarez/nvim-lsp-ts-utils',
+    dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
+    config = function()
+      local ts_utils = require 'nvim-lsp-ts-utils'
+      ts_utils.setup {
+        enable_import_on_completion = true,
+      }
+
+      vim.api.nvim_create_autocmd('LspAttach', {
+        callback = function(args)
+          local client = vim.lsp.get_client_by_id(args.data.client_id)
+          if client and client.name == 'tsserver' then
+            ts_utils.setup_client(client)
+          end
+        end,
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- enable custom plugin import
- add nvim-lsp-ts-utils plugin and set enable_import_on_completion
- activate tsserver in LSP servers

## Testing
- `nvim --headless -c "quit"` *(fails: nvim not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68628cc2694883228dcf4253ab6ebc73