### PR TITLE
Fix TypeScript imports with completion

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -882,10 +882,25 @@ require('lazy').setup({
       -- the rust implementation via `'prefer_rust_with_warning'`
       --
       -- See :h blink-cmp-config-fuzzy for more information
-      fuzzy = { implementation = 'lua' },
+  fuzzy = { implementation = 'lua' },
 
       -- Shows a signature help window while you type arguments for a function
       signature = { enabled = true },
+    },
+  },
+
+  {
+    'pmizio/typescript-tools.nvim',
+    event = { 'BufReadPre', 'BufNewFile' },
+    dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
+    opts = {
+      settings = {
+        complete_function_calls = true,
+        tsserver_file_preferences = {
+          includeCompletionsForModuleExports = true,
+          includeCompletionsForImportStatements = true,
+        },
+      },
     },
   },
 


### PR DESCRIPTION
## Summary
- install `pmizio/typescript-tools.nvim`
- enable auto imports and function call completions

## Testing
- `luacheck -v` *(fails: command not found)*
- `lua -v` *(fails: command not found)*
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686290a38c2c832291d96246aec0c853